### PR TITLE
Data cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 	<plugin>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-compiler-plugin</artifactId>
-		<version>2.3.2</version>
+		<version>3.5.1</version>
 		<configuration>
 			<source>1.8</source>
 			<target>1.8</target>
@@ -30,7 +30,7 @@
 	<plugin>
 		<groupId>org.apache.maven.plugins</groupId>
 		<artifactId>maven-jar-plugin</artifactId>
-		<version>3.0.0</version>
+		<version>3.0.2</version>
 		<configuration>
 		  <!-- DO NOT include log4j.properties file in your Jar -->
 		  <excludes>

--- a/src/main/java/edu/tamu/di/SAFCreator/ImportDataProcessorImpl.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/ImportDataProcessorImpl.java
@@ -143,7 +143,7 @@ public class ImportDataProcessorImpl implements ImportDataProcessor
 						String[] values = cell.split("\\|\\|");
 						for(int valueCounter = 0; valueCounter < numberOfValues; valueCounter++)
 						{
-							String value = values[valueCounter];
+							String value = values[valueCounter].trim();
 							Field field = new Field();
 							field.setSchema(schema);
 							field.setLabel(fieldLabel);
@@ -165,7 +165,7 @@ public class ImportDataProcessorImpl implements ImportDataProcessor
 						String[] values = cell.split("\\|\\|");
 						for(int valueCounter = 0; valueCounter < numberOfValues; valueCounter++)
 						{
-							String value = values[valueCounter];
+							String value = values[valueCounter].trim();
 							//if the value is of the form foo/* then get all the files in foo
 							//otherwise, just get the single named file
 							if(value.endsWith(File.separator + "*"))

--- a/src/main/java/edu/tamu/di/SAFCreator/Util.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/Util.java
@@ -49,7 +49,7 @@ public class Util {
 	protected static String getSchemaName(String string)
 	{
 		string = removeLanguage(string);
-		return string.split("\\.")[0];
+		return string.split("\\.")[0].trim();
 	}
 	
 	protected static String getElementName(String string)
@@ -60,6 +60,7 @@ public class Util {
 		if(string.lastIndexOf('.') != string.indexOf('.'))
 		{
 			String name = string.substring(string.indexOf('.')+1, string.lastIndexOf('.'));
+			name = name.trim().toLowerCase();
 			//System.out.println("Got name:"+name);
 			return name;
 		}
@@ -77,6 +78,7 @@ public class Util {
 		if(string.lastIndexOf('.') != string.indexOf('.'))
 		{	
 			String qualifier = string.substring(string.lastIndexOf('.')+1);
+			qualifier = qualifier.trim().toLowerCase();
 			//System.out.println("Got qualifier: "+qualifier);
 			return qualifier;
 		}

--- a/src/main/java/edu/tamu/di/SAFCreator/Util.java
+++ b/src/main/java/edu/tamu/di/SAFCreator/Util.java
@@ -49,7 +49,7 @@ public class Util {
 	protected static String getSchemaName(String string)
 	{
 		string = removeLanguage(string);
-		return string.split("\\.")[0].trim();
+		return string.split("\\.")[0].trim().toLowerCase();
 	}
 	
 	protected static String getElementName(String string)


### PR DESCRIPTION
We've had some issues with SAFCreator output containing extra whitespace in the DC metadata that causes the XML to not validate and the import job to fail. It has to do with typos in the column labels of the spreadsheet, or in some cases they were capitalized on accident. These problems are with the spreadsheets, _not_ the SAFCreator code. But I feel like some defensive strategies when parsing the CSV file wouldn't hurt. Let me know what you think.
